### PR TITLE
Bug Missing image on Kubernetes page #591

### DIFF
--- a/src/Pages/AllResources/devopsALL/kubernetes.jsx
+++ b/src/Pages/AllResources/devopsALL/kubernetes.jsx
@@ -159,7 +159,7 @@ export const KUBERNETES = () => {
 const resources = [
   {
     title: "Kubernetes - Docs",
-    image: "https://kubernetes.io/images/favicon.png",
+    image: "https://cdn2.iconfinder.com/data/icons/mixd/512/20_kubernetes-1024.png",
     type: "Documentation",
     link: "https://kubernetes.io/docs/home/",
   },


### PR DESCRIPTION
[Bug]: Missing image on Kubernetes page #591

Kubernetes Image Added

![image](https://github.com/user-attachments/assets/4a7ee1e6-c1df-423d-934c-ce4b75d30cf6)
