### PR TITLE
Fix incorrect repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ it is an Issue or a Pull Request.
 
 - Clone the Forked Repository to your local machine.
   ```
-  git clone https://github.com/<username>/namespace-community-website
+  git clone https://github.com/namespacecomm/namespace-community-website
   ```
 - Change the directory to namespace-community-website.
   ```bash


### PR DESCRIPTION
## Fixes Issue

This PR fixes the following issue(s):

- Fixed incorrect repository URL in the README, which used `<username>` instead of the correct GitHub namespace `namespacecomm`.

## Changes proposed

- Updated all instances of `<username>` in the repository URLs to use `namespacecomm`.

## Check List (Check all the boxes which are applicable)

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots and video

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/2c0d729f-2b4a-43ef-99a5-a6594a1d9b7b">
